### PR TITLE
Keep "hide until updates available" enabled after autostart and disable ...

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+mx-updater (25.12.01mx25) mx; urgency=medium
+
+  * Keep 'hide until updates available' enabled after autostart
+  * Disable non-working notification callbacks in Enlightenment
+
+ -- fehlix <fehlix@mxlinux.org>  Wed, 03 Dec 2025 17:56:55 -0500
+
 mx-updater (25.11.02mx25) mx; urgency=medium
 
   * Set no-autoremove for "nala" and "apt" to avoid kernel removal

--- a/libexec/mx-updater/updater-launch.py
+++ b/libexec/mx-updater/updater-launch.py
@@ -175,8 +175,8 @@ delay = max(0, delay)
 
 # delay launch if autostart is specified
 if args.autostart:
+    launch_args += ['--autostart']
     if delay > 0:
-        launch_args += ['--autostart'] 
         logger.info(f"MX Updater autostart is waiting {delay} seconds before starting")
         time.sleep(delay)
 
@@ -193,9 +193,6 @@ logger.info("MX Updater systray icon start:")
 ret=0
 while True:
     if args.debug:
-        print()
-        print(" ".join(launch_args[:-2]).replace("--", "\n--"))
-        print(" ".join(launch_args[-2:]))
         logger.info(" ")
         logger.info(" ".join(launch_args[:-2]).replace("--", "\n--"))
         logger.info(" ".join(launch_args[-2:]))

--- a/libexec/mx-updater/updater-systray.py
+++ b/libexec/mx-updater/updater-systray.py
@@ -915,8 +915,11 @@ class SystemTrayIcon(QSystemTrayIcon):
         n.set_urgency(notify2.URGENCY_NORMAL)
         n.set_timeout(10000)  # 10 seconds
 
-        # action callback if avialable
-        if "actions" in self._notify_caps:
+        has_actions = 'actions' in self._notify_caps
+        is_not_enlightenment = os.environ.get('DESKTOP', '').lower() != 'enlightenment'
+
+        # action callback if available - not working in Enlightenment
+        if has_actions and is_not_enlightenment:
             def on_notify_action(n_obj, action_key):
                 # action_key will be equal to action_tag by our choice below
                 launcher = self.make_launcher(action_key)


### PR DESCRIPTION
 ... non-working notification callbacks in Enlightenment