### PR TITLE
add python3-xdg to depends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -23,6 +23,7 @@ Depends:
  python3-colorama,
  python3-psutil,
  python3-pydbus,
+ python3-xdg,
  unattended-upgrades,
  util-linux-locales,
  xdotool,


### PR DESCRIPTION
required on the pi, which does not have it installed by default.